### PR TITLE
[WIP]: Reliant/Swift: Context substitution 

### DIFF
--- a/SwiftDraft/ReliantFramework/ReliantFramework/ReliantContext.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFramework/ReliantContext.swift
@@ -14,7 +14,6 @@ public protocol ReliantContext {
     static func createContext() -> ContextType
 }
 
-
 public protocol ReliantContextHolder {
     typealias ContextType : ReliantContext
     var context:ContextType { get }

--- a/SwiftDraft/ReliantFramework/ReliantFramework/RelyOn.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFramework/RelyOn.swift
@@ -9,19 +9,30 @@
 import Foundation
 
 struct ContextCache {
-    typealias ContextCacheType = Dictionary<String, Any>
-
     // If we're only going to use a static cache, we might as well use a struct?
-    static var standard = ContextCacheType()
+    static var standard = [String:Any]()
+    
+    static var substitutions = [String:Any.Type]()
 }
 
 public func relyOn<T:ReliantContext>(type:T.Type) -> T.ContextType {
-    if let result = ContextCache.standard[String(type)] {
-        // Forced downcast could be dangerous?
+    let typeKey = String(type)
+    if let result = ContextCache.standard[typeKey] {
         return result as! T.ContextType
     } else {
-        let result = type.createContext()
+        var result:T.ContextType
+        
+        if let substitutionType = ContextCache.substitutions[typeKey] as? T.Type {
+            result = substitutionType.createContext()
+        } else {
+            result = type.createContext()
+        }
+        
         ContextCache.standard[String(type)] = result
         return result;
     }
+}
+
+public func relyOnSubstitute<T:ReliantContext>(type:T.Type)(_ otherType:T.Type) {
+    ContextCache.substitutions[String(type)] = otherType
 }

--- a/SwiftDraft/ReliantFramework/ReliantFramework/RelyOn.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFramework/RelyOn.swift
@@ -8,17 +8,20 @@
 
 import Foundation
 
-class ContextCache {
-    static let sharedInstance:ContextCache = ContextCache()
-    var cache:Dictionary<String, Any> = Dictionary()
+struct ContextCache {
+    typealias ContextCacheType = Dictionary<String, Any>
+
+    // If we're only going to use a static cache, we might as well use a struct?
+    static var standard = ContextCacheType()
 }
 
 public func relyOn<T:ReliantContext>(type:T.Type) -> T.ContextType {
-    if let result = ContextCache.sharedInstance.cache[String(type)] {
+    if let result = ContextCache.standard[String(type)] {
+        // Forced downcast could be dangerous?
         return result as! T.ContextType
     } else {
         let result = type.createContext()
-        ContextCache.sharedInstance.cache[String(type)] = result
+        ContextCache.standard[String(type)] = result
         return result;
     }
 }

--- a/SwiftDraft/ReliantFramework/ReliantFrameworkTests/ReliantFrameworkTests.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFrameworkTests/ReliantFrameworkTests.swift
@@ -54,10 +54,18 @@ struct ContextNeedingContext : ReliantContext {
         return ContextNeedingContext()
     }
 }
+class SubWaver : Waver {
+    func wave(reason: String) -> String {
+        return "Substitute waving"
+    }
+}
 
-
-
-
+class SubstituteContext : SimpleReferenceContext {
+    override init() {
+        super.init()
+        waver = SubWaver()
+    }
+}
 
 class ReliantFrameworkTests: XCTestCase {
     
@@ -84,6 +92,17 @@ class ReliantFrameworkTests: XCTestCase {
         XCTAssertEqual(needed.needy.decorateGreeting(), "Oh! Hello Needy")
     }
     
-    
+    func testSubstitutions() {
+        relyOnSubstitute(SimpleReferenceContext)(SubstituteContext)
+        XCTAssertTrue(ContextCache.substitutions.contains({ (key, value) -> Bool in
+            return key == String(SimpleReferenceContext) && value == SubstituteContext.self
+        }))
         
+        let context = relyOn(SimpleReferenceContext)
+                
+        // Failing test.
+        // The createContext() function is static and thus final. Actual context type seems
+        // to be correct, but createContext() is called on original context class
+        XCTAssertTrue(context is SubstituteContext)
+    }
 }

--- a/SwiftDraft/ReliantFramework/ReliantFrameworkTests/ReliantFrameworkTests.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFrameworkTests/ReliantFrameworkTests.swift
@@ -64,7 +64,7 @@ class ReliantFrameworkTests: XCTestCase {
     override func setUp() {
         super.setUp()
         ReliantFrameworkTestsHelper.sharedInsance.reset()
-        ContextCache.sharedInstance.cache = Dictionary()
+        ContextCache.standard.removeAll()
     }
     
     func testRelyOnReturnsSameInsanceEveryTimeForReferenceTypes() {

--- a/SwiftDraft/ReliantFramework/ReliantFrameworkTests/SimpleReferenceContext.swift
+++ b/SwiftDraft/ReliantFramework/ReliantFrameworkTests/SimpleReferenceContext.swift
@@ -12,8 +12,8 @@ import Reliant
 class SimpleReferenceContext : ReliantContext {
     private let bothWorlds = BothWorlds(prefix:"Hello")
     
-    let waver:Waver
-    let greeter:Greeter
+    var waver:Waver
+    var greeter:Greeter
     
     init() {
         ReliantFrameworkTestsHelper.sharedInsance.markInitCalled()


### PR DESCRIPTION
⚠️ **Work-in-progress**, do not merge ⚠️

Exploring a way to register context substitutions so they can be swapped out for testing or other purposes. 
# Current implementation

I added a map to the context cache which will be accessible through `relyOnSubstitute(T)(T)`. This global function simply creates an entry in the map, which `relyOn()` will then use to determine if it needs to create a substitute context or a normal one, when requested.
## Remarks

I have only gotten this to work half-way. The substitute type is registered and found correctly, but when its `createContext()` function is invoked, the original, non-substituted version is called because `createContext()` is `static` with no way to override it, because `static` also means `final` in Swift. 

Because of how I set up the `relyOnSubstitute`'s arguments (both of the same type `T:ReliantContext`), the second argument needs to resolve to the same type as the first. That is, the second argument needs to be covariant with the first. This is currently achieved by subclassing the original context, with currently no way to modify `createContext()`'s implementation due to the reason stated above.

Subclassing doesn't feel right, so I'm currently exploring ways to change `relyOnSubstitute`s signature to something like:

``` swift
public func relyOnSubstitute<T:ReliantContext, S:ReliantContext>(type:T.Type)(_ otherType:S.Type)
```

This causes serious type resolution problems of course, so I'm still trying to figure something out.
